### PR TITLE
Bug search return 404 gracefully

### DIFF
--- a/app/Http/Controllers/DataController.php
+++ b/app/Http/Controllers/DataController.php
@@ -34,11 +34,14 @@ class DataController extends Controller
         $champion = Champion::select('name')->firstWhere('name', $search);
         
         if($champion == null){
-            return redirect('summoner/' . $search);
+            $summoner = Summoner::select('name')->firstWhere('name', $search);
+            
+            if($summoner != null){
+                return redirect('summoner/' . $search);
+            }
+            return redirect('/')->withSuccess("No summoner or champion found with name " . $search);
         }
-        else{
-            return redirect('champion/' . $champion->name);
-        }
+        return redirect('champion/' . $champion->name);
     }
 
     // Get summoner by name, get all relevant info and all the games played by this summoner and pass it to page.

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -10,6 +10,12 @@
     <div class="flex h-screen items-center justify-center">
         <div class="grid w-7/12 m-auto">
             @include('searchBar')
+
+            @if (session('success'))
+            <div class="alert alert-danger w-auto m-auto mt-2">
+                {{ session('success') }}
+            </div>
+            @endif
         </div>
     </div>   
 </body>


### PR DESCRIPTION
Search returned an error when it could not find a summoner or a champion with the searched name. Now checks both, summoner and champion name, and then if neither is found shows an informational alert.