### PR TITLE
Bug latest matches sorted wrong

### DIFF
--- a/app/Models/SummonerMatch.php
+++ b/app/Models/SummonerMatch.php
@@ -19,7 +19,8 @@ class SummonerMatch extends Model
         'didWin',
         'match_id',
         'team',
-        'farm'
+        'farm',
+        'game_date'
     ];
 
     protected $primaryKey = 'summoner_match_id';


### PR DESCRIPTION
Add game_date field to database so Laravel could easily sort all summoner matches by game_date. This fixes the wrong order of latest matches on summoner profile and champion profiles.