### PR TITLE
Add new exception for replay book data

### DIFF
--- a/app/Extensions/ReplaybookDataConvert.php
+++ b/app/Extensions/ReplaybookDataConvert.php
@@ -40,6 +40,8 @@ class ReplaybookDataConvert
                 return 223;
             case "reksai":
                 return 421;
+            case "belveth":
+                return 200;
             default:
                 return null;
         }


### PR DESCRIPTION
A new champion added to League of Legends has a different name in the data given by the official page and the games replay data.